### PR TITLE
Allow to set only height as downsampling size.

### DIFF
--- a/.swiftpm/xcode/xcshareddata/xcschemes/AsyncDownSamplingImage.xcscheme
+++ b/.swiftpm/xcode/xcshareddata/xcschemes/AsyncDownSamplingImage.xcscheme
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1540"
+   version = "1.7">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES"
+      buildArchitectures = "Automatic">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AsyncDownSamplingImage"
+               BuildableName = "AsyncDownSamplingImage"
+               BlueprintName = "AsyncDownSamplingImage"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      shouldAutocreateTestPlan = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AsyncDownSamplingImageTests"
+               BuildableName = "AsyncDownSamplingImageTests"
+               BlueprintName = "AsyncDownSamplingImageTests"
+               ReferencedContainer = "container:">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AsyncDownSamplingImage"
+            BuildableName = "AsyncDownSamplingImage"
+            BlueprintName = "AsyncDownSamplingImage"
+            ReferencedContainer = "container:">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -9,8 +9,11 @@
 /* Begin PBXBuildFile section */
 		D30592B4298C9F830060D5EE /* AsyncDownSamplingImage in Frameworks */ = {isa = PBXBuildFile; productRef = D30592B3298C9F830060D5EE /* AsyncDownSamplingImage */; };
 		D36AB81B2C38C38500F37D8F /* DownsampleGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */; };
+		D36AB81D2C38C3F900F37D8F /* DownSamplingVStackView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB81C2C38C3F900F37D8F /* DownSamplingVStackView.swift */; };
+		D36AB81F2C38C48400F37D8F /* StandardView+Grid.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB81E2C38C48400F37D8F /* StandardView+Grid.swift */; };
+		D36AB8212C38C4AB00F37D8F /* StandardView+VStack.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB8202C38C4AB00F37D8F /* StandardView+VStack.swift */; };
+		D36AB8232C38C74300F37D8F /* Util.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB8222C38C74300F37D8F /* Util.swift */; };
 		D3E99FFE298C9EEF006E08E2 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */; };
-		D3E9A000298C9EEF006E08E2 /* DefaultContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */; };
 		D3E9A002298C9EF1006E08E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3E9A001298C9EF1006E08E2 /* Assets.xcassets */; };
 		D3E9A006298C9EF1006E08E2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3E9A005298C9EF1006E08E2 /* Preview Assets.xcassets */; };
 /* End PBXBuildFile section */
@@ -18,9 +21,12 @@
 /* Begin PBXFileReference section */
 		D30592B1298C9F7F0060D5EE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownsampleGridView.swift; sourceTree = "<group>"; };
+		D36AB81C2C38C3F900F37D8F /* DownSamplingVStackView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownSamplingVStackView.swift; sourceTree = "<group>"; };
+		D36AB81E2C38C48400F37D8F /* StandardView+Grid.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "StandardView+Grid.swift"; sourceTree = "<group>"; };
+		D36AB8202C38C4AB00F37D8F /* StandardView+VStack.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StandardView+VStack.swift"; sourceTree = "<group>"; };
+		D36AB8222C38C74300F37D8F /* Util.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Util.swift; sourceTree = "<group>"; };
 		D3E99FFA298C9EEF006E08E2 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
-		D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultContentView.swift; sourceTree = "<group>"; };
 		D3E9A001298C9EF1006E08E2 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		D3E9A003298C9EF1006E08E2 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		D3E9A005298C9EF1006E08E2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
@@ -69,9 +75,12 @@
 			children = (
 				D3E9A003298C9EF1006E08E2 /* Example.entitlements */,
 				D30592B1298C9F7F0060D5EE /* Info.plist */,
-				D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */,
 				D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */,
+				D36AB81C2C38C3F900F37D8F /* DownSamplingVStackView.swift */,
 				D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */,
+				D36AB81E2C38C48400F37D8F /* StandardView+Grid.swift */,
+				D36AB8202C38C4AB00F37D8F /* StandardView+VStack.swift */,
+				D36AB8222C38C74300F37D8F /* Util.swift */,
 				D3E9A001298C9EF1006E08E2 /* Assets.xcassets */,
 				D3E9A004298C9EF1006E08E2 /* Preview Content */,
 			);
@@ -168,7 +177,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				D36AB81B2C38C38500F37D8F /* DownsampleGridView.swift in Sources */,
-				D3E9A000298C9EEF006E08E2 /* DefaultContentView.swift in Sources */,
+				D36AB8232C38C74300F37D8F /* Util.swift in Sources */,
+				D36AB81D2C38C3F900F37D8F /* DownSamplingVStackView.swift in Sources */,
+				D36AB81F2C38C48400F37D8F /* StandardView+Grid.swift in Sources */,
+				D36AB8212C38C4AB00F37D8F /* StandardView+VStack.swift in Sources */,
 				D3E99FFE298C9EEF006E08E2 /* ExampleApp.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Example/Example.xcodeproj/project.pbxproj
+++ b/Example/Example.xcodeproj/project.pbxproj
@@ -8,15 +8,16 @@
 
 /* Begin PBXBuildFile section */
 		D30592B4298C9F830060D5EE /* AsyncDownSamplingImage in Frameworks */ = {isa = PBXBuildFile; productRef = D30592B3298C9F830060D5EE /* AsyncDownSamplingImage */; };
+		D36AB81B2C38C38500F37D8F /* DownsampleGridView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */; };
 		D3E99FFE298C9EEF006E08E2 /* ExampleApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */; };
 		D3E9A000298C9EEF006E08E2 /* DefaultContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */; };
 		D3E9A002298C9EF1006E08E2 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3E9A001298C9EF1006E08E2 /* Assets.xcassets */; };
 		D3E9A006298C9EF1006E08E2 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = D3E9A005298C9EF1006E08E2 /* Preview Assets.xcassets */; };
-		D3F22F9B29900A2E005365E3 /* DownsampleContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F22F9A29900A2E005365E3 /* DownsampleContentView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
 		D30592B1298C9F7F0060D5EE /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DownsampleGridView.swift; sourceTree = "<group>"; };
 		D3E99FFA298C9EEF006E08E2 /* Example.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Example.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExampleApp.swift; sourceTree = "<group>"; };
 		D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultContentView.swift; sourceTree = "<group>"; };
@@ -24,7 +25,6 @@
 		D3E9A003298C9EF1006E08E2 /* Example.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Example.entitlements; sourceTree = "<group>"; };
 		D3E9A005298C9EF1006E08E2 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		D3E9A00D298C9F06006E08E2 /* AsyncDownSamplingImage */ = {isa = PBXFileReference; lastKnownFileType = wrapper; name = AsyncDownSamplingImage; path = ..; sourceTree = "<group>"; };
-		D3F22F9A29900A2E005365E3 /* DownsampleContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DownsampleContentView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -70,7 +70,7 @@
 				D3E9A003298C9EF1006E08E2 /* Example.entitlements */,
 				D30592B1298C9F7F0060D5EE /* Info.plist */,
 				D3E99FFF298C9EEF006E08E2 /* DefaultContentView.swift */,
-				D3F22F9A29900A2E005365E3 /* DownsampleContentView.swift */,
+				D36AB81A2C38C38500F37D8F /* DownsampleGridView.swift */,
 				D3E99FFD298C9EEF006E08E2 /* ExampleApp.swift */,
 				D3E9A001298C9EF1006E08E2 /* Assets.xcassets */,
 				D3E9A004298C9EF1006E08E2 /* Preview Content */,
@@ -167,9 +167,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D36AB81B2C38C38500F37D8F /* DownsampleGridView.swift in Sources */,
 				D3E9A000298C9EEF006E08E2 /* DefaultContentView.swift in Sources */,
 				D3E99FFE298C9EEF006E08E2 /* ExampleApp.swift in Sources */,
-				D3F22F9B29900A2E005365E3 /* DownsampleContentView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Example/Example.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "10bc670db657d11bdd561e07de30a9041311b2b1",
-        "version" : "1.1.0"
+        "revision" : "26ac5758409154cc448d7ab82389c520fa8a8247",
+        "version" : "1.3.0"
       }
     },
     {

--- a/Example/Example/DownSamplingVStackView.swift
+++ b/Example/Example/DownSamplingVStackView.swift
@@ -1,27 +1,31 @@
+//
+//  DownSamplingVStackView.swift
+//  Example
+//
+//  Created by Fumiya Tanaka on 2024/07/06.
+//
+
 import SwiftUI
 import AsyncDownSamplingImage
 
-struct DownsampleGridView: View {
-
-    @State private var url = Util.Grid.url
-    @State private var size: CGSize = .init(width: 160, height: 160)
+struct DownSamplingVStackView: View {
+    
+    @State private var url = Util.VStack.url
+    @State private var height: Double = 240
 
     var body: some View {
         VStack {
             Text("AsyncDownSamplingImage")
             ScrollView {
-                LazyVGrid(columns: [.init(), .init()]) {
+                LazyVStack() {
                     ForEach(0..<1000, id: \.self) { _ in
                         AsyncDownSamplingImage(
                             url: url,
-                            downsampleSize: .size(Util.Grid.bufferedImageSize)
+                            downsampleSize: .height(Util.VStack.bufferedImageHeight)
                         ) { image in
                             image.resizable()
                                 .aspectRatio(contentMode: .fit)
-                                .frame(
-                                    width: size.width,
-                                    height: size.height
-                                )
+                                .frame(height: height)
                         } onFail: { error in
                             Text("Error: \(error.localizedDescription)")
                         }
@@ -33,8 +37,6 @@ struct DownsampleGridView: View {
     }
 }
 
-struct DownsampleContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        DownsampleGridView()
-    }
+#Preview {
+    DownSamplingVStackView()
 }

--- a/Example/Example/DownSamplingVStackView.swift
+++ b/Example/Example/DownSamplingVStackView.swift
@@ -21,7 +21,9 @@ struct DownSamplingVStackView: View {
                     ForEach(0..<1000, id: \.self) { _ in
                         AsyncDownSamplingImage(
                             url: url,
-                            downsampleSize: .height(Util.VStack.bufferedImageHeight)
+                            downsampleSize: .height(
+                                Util.VStack.bufferedImageHeight
+                            )
                         ) { image in
                             image.resizable()
                                 .aspectRatio(contentMode: .fit)

--- a/Example/Example/DownsampleGridView.swift
+++ b/Example/Example/DownsampleGridView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import AsyncDownSamplingImage
 
-struct DownsampleContentView: View {
+struct DownsampleGridView: View {
 
     @State private var url = URL(string: "https://picsum.photos/1000")
     @State private var size: CGSize = .init(width: 160, height: 160)
@@ -14,11 +14,11 @@ struct DownsampleContentView: View {
                     ForEach(0..<1000, id: \.self) { _ in
                         AsyncDownSamplingImage(
                             url: url,
-                            downsampleSize: size
+                            downsampleSize: .size(size)
                         ) { image in
                             image.resizable()
                                 .frame(width: size.width, height: size.height)
-                        } fail: { error in
+                        } onFail: { error in
                             Text("Error: \(error.localizedDescription)")
                         }
                     }
@@ -31,6 +31,6 @@ struct DownsampleContentView: View {
 
 struct DownsampleContentView_Previews: PreviewProvider {
     static var previews: some View {
-        DownsampleContentView()
+        DownsampleGridView()
     }
 }

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -12,7 +12,7 @@ struct ExampleApp: App {
     var body: some Scene {
         WindowGroup {
             DefaultContentView()
-            DownsampleContentView()
+            DownsampleGridView()
         }
     }
 }

--- a/Example/Example/ExampleApp.swift
+++ b/Example/Example/ExampleApp.swift
@@ -11,8 +11,26 @@ import SwiftUI
 struct ExampleApp: App {
     var body: some Scene {
         WindowGroup {
-            DefaultContentView()
-            DownsampleGridView()
+            TabView {
+                VStack {
+                    StandardView_Grid()
+                    DownsampleGridView()
+                }
+                .tabItem {
+                    Image(systemName: "1.circle")
+                    Text("Grid")
+                }
+                .tag("Grid")
+                VStack {
+                    StandardView_VStack()
+                    DownSamplingVStackView()
+                }
+                .tabItem {
+                    Image(systemName: "2.circle")
+                    Text("VStack")
+                }
+                .tag("VStack")
+            }
         }
     }
 }

--- a/Example/Example/StandardView+Grid.swift
+++ b/Example/Example/StandardView+Grid.swift
@@ -1,8 +1,8 @@
 import SwiftUI
 
-struct DefaultContentView: View {
+struct StandardView_Grid: View {
 
-    @State private var url = URL(string: "https://picsum.photos/1000")
+    @State private var url = Util.Grid.url
     @State private var size: CGSize = .init(width: 160, height: 160)
 
     var body: some View {
@@ -19,7 +19,11 @@ struct DefaultContentView: View {
                                 Text("Error: \(error.localizedDescription)")
                             case .success(let image):
                                 image.resizable()
-                                    .frame(width: size.width, height: size.height)
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(
+                                        width: size.width,
+                                        height: size.height
+                                    )
                             @unknown default:
                                 fatalError()
                             }
@@ -32,8 +36,6 @@ struct DefaultContentView: View {
     }
 }
 
-struct DefaultContentView_Previews: PreviewProvider {
-    static var previews: some View {
-        DefaultContentView()
-    }
+#Preview {
+    StandardView_Grid()
 }

--- a/Example/Example/StandardView+VStack.swift
+++ b/Example/Example/StandardView+VStack.swift
@@ -1,0 +1,45 @@
+//
+//  StandardView+VStack.swift
+//  Example
+//
+//  Created by Fumiya Tanaka on 2024/07/06.
+//
+
+import SwiftUI
+
+struct StandardView_VStack: View {
+
+    @State private var url = Util.VStack.url
+    @State private var height: Double = 240
+
+    var body: some View {
+        VStack {
+            Text("Default AsyncImage")
+            ScrollView {
+                LazyVStack() {
+                    ForEach(0..<1000, id: \.self) { _ in
+                        AsyncImage(url: url) { phase in
+                            switch phase {
+                            case .empty:
+                                ProgressView().progressViewStyle(.circular)
+                            case .failure(let error):
+                                Text("Error: \(error.localizedDescription)")
+                            case .success(let image):
+                                image.resizable()
+                                    .aspectRatio(contentMode: .fit)
+                                    .frame(height: height)
+                            @unknown default:
+                                fatalError()
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        .padding()
+    }
+}
+
+#Preview {
+    StandardView_VStack()
+}

--- a/Example/Example/Util.swift
+++ b/Example/Example/Util.swift
@@ -1,0 +1,19 @@
+//
+//  Util.swift
+//  Example
+//
+//  Created by Fumiya Tanaka on 2024/07/06.
+//
+
+import Foundation
+
+enum Util {
+    enum Grid {
+        static let url = URL(string: "https://picsum.photos/1000/1000")
+        static let bufferedImageSize = CGSize(width: 160, height: 160)
+    }
+    enum VStack {
+        static let url = URL(string: "https://picsum.photos/800/600")
+        static let bufferedImageHeight = 320.0
+    }
+}

--- a/Package.swift
+++ b/Package.swift
@@ -16,7 +16,7 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
         .package(
-            url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"
+            url: "https://github.com/apple/swift-docc-plugin", from: "1.3.0"
         )
     ],
     targets: [

--- a/README.md
+++ b/README.md
@@ -95,3 +95,7 @@ Pull requests, bug reports and feature requests are welcome 🚀
 # License
 
 [MIT LICENSE](https://github.com/fummicc1/AsyncDownSamplingImage/blob/main/LICENSE)
+
+# Reference
+
+- https://medium.com/@zippicoder/downsampling-images-for-better-memory-consumption-and-uicollectionview-performance-35e0b4526425

--- a/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
+++ b/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
@@ -255,14 +255,14 @@ extension AsyncDownSamplingImage {
         url: URL?,
         downsampleSize: DownSamplingSize,
         content: @escaping (Image) -> Content,
-        placeholder: @escaping () -> Placeholder,
-        fail: @escaping (any Error) -> Fail
+        onLoading: @escaping () -> Placeholder,
+        onFail: @escaping (any Error) -> Fail
     ) {
         self._url = .constant(url)
         self._downsampleSize = .constant(downsampleSize)
         self.content = content
-        self.onLoading = placeholder
-        self.onFail = fail
+        self.onLoading = onLoading
+        self.onFail = onFail
         self.status = status
     }
 }

--- a/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
+++ b/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
@@ -25,11 +25,11 @@ private enum LoadingOpacityEdge {
 }
 
 public enum DownSamplingSize {
-    case size(CGSize, scale: Double)
-    case width(Double, scale: Double)
-    case height(Double, scale: Double)
+    case size(CGSize, scale: Double = 1)
+    case width(Double, scale: Double = 1)
+    case height(Double, scale: Double = 1)
 
-    var width: Double? {
+    public var width: Double? {
         switch self {
         case .size(let cGSize, _):
             cGSize.width
@@ -40,7 +40,7 @@ public enum DownSamplingSize {
         }
     }
 
-    var height: Double? {
+    public var height: Double? {
         switch self {
         case .size(let cGSize, _):
             cGSize.height

--- a/Sources/AsyncDownSamplingImage/Downsampling.swift
+++ b/Sources/AsyncDownSamplingImage/Downsampling.swift
@@ -9,8 +9,7 @@ struct DownSampling {
 
     static func perform(
         at url: URL,
-        size: DownSamplingSize,
-        scale: CGFloat = 1
+        size: DownSamplingSize
     ) async throws -> CGImage {
         let imageSourceOption = [kCGImageSourceShouldCache: true] as CFDictionary
         guard let imageSource = CGImageSourceCreateWithURL(url as CFURL, imageSourceOption) else {

--- a/Sources/AsyncDownSamplingImage/TypeCompatibility.swift
+++ b/Sources/AsyncDownSamplingImage/TypeCompatibility.swift
@@ -1,11 +1,6 @@
 #if os(iOS)
 import UIKit
 typealias ImageType = UIImage
-extension ImageType {
-    convenience init(cgImage: CGImage, size: CGSize) {
-        self.init(cgImage: cgImage)
-    }
-}
 #elseif os(macOS)
 import AppKit
 typealias ImageType = NSImage


### PR DESCRIPTION
- close #10 

- User can set either height or width as downsampling size
- Rename some of initializer arguments
  - placeholder → onLoading
  - fail → onFail


https://github.com/fummicc1/AsyncDownSamplingImage/assets/44002126/868364a1-9d72-4482-9ac4-ef902be50528

