### PR TITLE
Improve loading view size when width or height is not specified

### DIFF
--- a/Example/Example/DownsampleGridView.swift
+++ b/Example/Example/DownsampleGridView.swift
@@ -5,7 +5,7 @@ struct DownsampleGridView: View {
 
     @State private var url = Util.Grid.url
     @State private var showsDetail: Bool = false
-    @State private var size: CGSize = .init(width: 160, height: 160)
+    @State private var height: Double = 160
 
     var body: some View {
         VStack {
@@ -18,13 +18,12 @@ struct DownsampleGridView: View {
                         } label: {
                             AsyncDownSamplingImage(
                                 url: url,
-                                downsampleSize: .size(Util.Grid.bufferedImageSize)
+                                downsampleSize: .height(height)
                             ) { image in
                                 image.resizable()
                                     .aspectRatio(contentMode: .fit)
                                     .frame(
-                                        width: size.width,
-                                        height: size.height
+                                        height: height
                                     )
                             } onFail: { error in
                                 Text("Error: \(error.localizedDescription)")

--- a/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
+++ b/Sources/AsyncDownSamplingImage/AsyncDownSamplingImage.swift
@@ -163,8 +163,9 @@ public struct AsyncDownSamplingImage<Content: View, Placeholder: View, Fail: Vie
                 value: loadingOpacity
             )
             .frame(
-                width: downsampleSize.size.width,
-                height: downsampleSize.size.height
+                // If both width and height are not provided, treat loading image as square.
+                width: downsampleSize.size.width ?? downsampleSize.size.height,
+                height: downsampleSize.size.height ?? downsampleSize.size.width
             )
             .redacted(reason: .placeholder)
             .onAppear {


### PR DESCRIPTION

Fix loading view size.

When width or height is nil in `DownsamplingSize`, loading view expands to infinite scale like the following `before` section.

I solve it by assuming loading view is square shape.

|before|after|
|---|---|
|<video src="https://github.com/user-attachments/assets/a041427d-1eae-4489-af41-8e326339a198">|<video src="https://github.com/user-attachments/assets/8bceb587-4c01-40a0-b733-3aeee7b30ea8">|

